### PR TITLE
Port to 1.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,9 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+### IntelliJ ###
+*.iml
+*.ipr
+*.iws
+

--- a/build.gradle
+++ b/build.gradle
@@ -4,24 +4,24 @@ buildscript {
         maven { url = "http://files.minecraftforge.net/maven" }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.2-SNAPSHOT'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
     }
 }
 apply plugin: 'net.minecraftforge.gradle.forge'
 //Only edit below this line, the above code adds and enables the nessasary things for Forge to be setup.
 
 
-version = "1.0.1"
+version = "1.1.0"
 group= "com.vashmeed.nvoid" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "nVoid"
 
-sourceCompatibility = targetCompatibility = "1.6" // Need this here so eclipse task generates correctly.
+sourceCompatibility = targetCompatibility = "1.8" // Need this here so eclipse task generates correctly.
 compileJava {
-    sourceCompatibility = targetCompatibility = "1.6"
+    sourceCompatibility = targetCompatibility = "1.8"
 }
 
 minecraft {
-    version = "1.10.2-12.18.2.2120"
+    version = "1.12.2-14.23.0.2503"
     runDir = "run"
     
     // the mappings can be changed at any time, and must be in the following format.
@@ -29,7 +29,7 @@ minecraft {
     // stable_#            stables are built at the discretion of the MCP team.
     // Use non-default mappings at your own risk. they may not allways work.
     // simply re-run your setup task after changing the mappings to update your workspace.
-    mappings = "snapshot_20160518"
+    mappings = "snapshot_20171003"
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 }
 

--- a/src/main/java/com/vashmeed/nvoid/nVoid.java
+++ b/src/main/java/com/vashmeed/nvoid/nVoid.java
@@ -1,7 +1,6 @@
 package com.vashmeed.nvoid;
 
 import com.vashmeed.nvoid.config.Config;
-import com.vashmeed.nvoid.proxy.CommonProxy;
 import com.vashmeed.nvoid.world.WorldProviderVoidEnd;
 import com.vashmeed.nvoid.world.WorldProviderVoidNether;
 import com.vashmeed.nvoid.world.WorldProviderVoidOverworld;
@@ -13,7 +12,6 @@ import net.minecraft.world.DimensionType;
 import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.SidedProxy;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
@@ -27,9 +25,6 @@ public class nVoid {
 	public static final String modId = "nvoid";
 	public static final String name = "nVoid";
 	public static final String version = "1.1.0";
-
-	@SidedProxy(serverSide = "com.vashmeed.nvoid.proxy.CommonProxy", clientSide = "com.vashmeed.nvoid.proxy.ClientProxy")
-	public static CommonProxy proxy;
 
 	@Mod.Instance(modId)
 	public static nVoid instance;
@@ -64,11 +59,6 @@ public class nVoid {
 			DimensionManager.registerDimension(1,
 					DimensionType.register("VoidEnd", "end", 1, WorldProviderVoidEnd.class, false));
 		}
-	}
-
-	@Mod.EventHandler
-	public void init(FMLInitializationEvent event) {
-
 	}
 
 	@Mod.EventHandler

--- a/src/main/java/com/vashmeed/nvoid/nVoid.java
+++ b/src/main/java/com/vashmeed/nvoid/nVoid.java
@@ -21,12 +21,12 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 /**
  * Created by Vaheed on 10/31/2016.
  */
-@Mod(modid = nVoid.modId, name = nVoid.name, version = nVoid.version, acceptedMinecraftVersions = "[1.9.4, 1.10.2, 1.11]")
+@Mod(modid = nVoid.modId, name = nVoid.name, version = nVoid.version, acceptedMinecraftVersions = "[1.12]")
 public class nVoid {
 
 	public static final String modId = "nvoid";
 	public static final String name = "nVoid";
-	public static final String version = "1.0";
+	public static final String version = "1.1.0";
 
 	@SidedProxy(serverSide = "com.vashmeed.nvoid.proxy.CommonProxy", clientSide = "com.vashmeed.nvoid.proxy.ClientProxy")
 	public static CommonProxy proxy;

--- a/src/main/java/com/vashmeed/nvoid/proxy/ClientProxy.java
+++ b/src/main/java/com/vashmeed/nvoid/proxy/ClientProxy.java
@@ -1,8 +1,0 @@
-package com.vashmeed.nvoid.proxy;
-
-/**
- * Created by Vaheed on 10/31/2016.
- */
-public class ClientProxy extends CommonProxy {
-
-}

--- a/src/main/java/com/vashmeed/nvoid/proxy/CommonProxy.java
+++ b/src/main/java/com/vashmeed/nvoid/proxy/CommonProxy.java
@@ -1,8 +1,0 @@
-package com.vashmeed.nvoid.proxy;
-
-/**
- * Created by Vaheed on 10/31/2016.
- */
-public class CommonProxy {
-
-}

--- a/src/main/java/com/vashmeed/nvoid/world/WorldProviderVoidEnd.java
+++ b/src/main/java/com/vashmeed/nvoid/world/WorldProviderVoidEnd.java
@@ -1,6 +1,7 @@
 package com.vashmeed.nvoid.world;
 
 import com.vashmeed.nvoid.config.Config;
+import com.vashmeed.nvoid.world.biome.VoidBiomeProvider;
 import com.vashmeed.nvoid.world.end.DragonFightVoid;
 import com.vashmeed.nvoid.world.gen.ChunkGeneratorVoidEnd;
 
@@ -20,7 +21,12 @@ public class WorldProviderVoidEnd extends WorldProviderEnd {
 	@Override
     public void init()
     {
-        this.biomeProvider = new BiomeProviderSingle(Biomes.SKY);
+    	if (Config.voidBiomeEnd) {
+    		this.biomeProvider = new BiomeProviderSingle(Biomes.SKY);
+		} else {
+			this.biomeProvider = new VoidBiomeProvider(world);
+		}
+
         if (Config.endDragonEnabled) {
             NBTTagCompound nbttagcompound = this.world.getWorldInfo().getDimensionData(DimensionType.THE_END.getId());
             this.dragonFightManager = this.world instanceof WorldServer ? new DragonFightVoid((WorldServer)this.world,

--- a/src/main/java/com/vashmeed/nvoid/world/WorldProviderVoidEnd.java
+++ b/src/main/java/com/vashmeed/nvoid/world/WorldProviderVoidEnd.java
@@ -3,7 +3,6 @@ package com.vashmeed.nvoid.world;
 import com.vashmeed.nvoid.config.Config;
 import com.vashmeed.nvoid.world.end.DragonFightVoid;
 import com.vashmeed.nvoid.world.gen.ChunkGeneratorVoidEnd;
-import com.vashmeed.nvoid.world.gen.ChunkGeneratorVoidIsland;
 
 import net.minecraft.init.Biomes;
 import net.minecraft.nbt.NBTTagCompound;
@@ -12,34 +11,32 @@ import net.minecraft.world.DimensionType;
 import net.minecraft.world.WorldProviderEnd;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.biome.BiomeProviderSingle;
-import net.minecraft.world.chunk.IChunkGenerator;
-import net.minecraft.world.end.DragonFightManager;
+import net.minecraft.world.gen.IChunkGenerator;
 
 public class WorldProviderVoidEnd extends WorldProviderEnd {
 
 	private DragonFightVoid dragonFightManager;
 	
 	@Override
-    public void createBiomeProvider()
+    public void init()
     {
         this.biomeProvider = new BiomeProviderSingle(Biomes.SKY);
-        this.hasNoSky = true;
         if (Config.endDragonEnabled) {
-            NBTTagCompound nbttagcompound = this.worldObj.getWorldInfo().getDimensionData(DimensionType.THE_END);
-            this.dragonFightManager = this.worldObj instanceof WorldServer ? new DragonFightVoid((WorldServer)this.worldObj, nbttagcompound.getCompoundTag("DragonFight")) : null;
+            NBTTagCompound nbttagcompound = this.world.getWorldInfo().getDimensionData(DimensionType.THE_END.getId());
+            this.dragonFightManager = this.world instanceof WorldServer ? new DragonFightVoid((WorldServer)this.world,
+					nbttagcompound.getCompoundTag("DragonFight")) : null;
         }
-    }
-	
+	}
+
 	@Override
 	public IChunkGenerator createChunkGenerator() {
-		//return new ChunkGeneratorVoidIsland(worldObj, hasNoSky, 1);
-		return new ChunkGeneratorVoidEnd(worldObj);
+		return new ChunkGeneratorVoidEnd(world);
 	}
 
 	@Override
 	public BlockPos getRandomizedSpawnPoint() {
-		BlockPos spawn = new BlockPos(worldObj.getSpawnPoint());
-		spawn = worldObj.getTopSolidOrLiquidBlock(spawn);
+		BlockPos spawn = new BlockPos(world.getSpawnPoint());
+		spawn = world.getTopSolidOrLiquidBlock(spawn);
 		return spawn;
 	}
 	

--- a/src/main/java/com/vashmeed/nvoid/world/WorldProviderVoidNether.java
+++ b/src/main/java/com/vashmeed/nvoid/world/WorldProviderVoidNether.java
@@ -5,11 +5,9 @@ import com.vashmeed.nvoid.world.gen.ChunkGeneratorVoidNether;
 
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.WorldProviderHell;
-import net.minecraft.world.chunk.IChunkGenerator;
+import net.minecraft.world.gen.IChunkGenerator;
 
-/**
- * Created by Vaheed on 10/31/2016.
- */
+
 public class WorldProviderVoidNether extends WorldProviderHell {
 
 	@Override
@@ -19,18 +17,20 @@ public class WorldProviderVoidNether extends WorldProviderHell {
 
 	@Override
 	public IChunkGenerator createChunkGenerator() {
-		return new ChunkGeneratorVoidNether(worldObj);
+		return new ChunkGeneratorVoidNether(world);
 	}
 
 	@Override
-	public void createBiomeProvider() {
-		this.biomeProvider = new VoidBiomeProvider(worldObj);
+	public void init() {
+		this.biomeProvider = new VoidBiomeProvider(world);
+		this.doesWaterVaporize = true;
+		this.nether = true;
 	}
 
 	@Override
 	public BlockPos getRandomizedSpawnPoint() {
-		BlockPos spawn = new BlockPos(worldObj.getSpawnPoint());
-		spawn = worldObj.getTopSolidOrLiquidBlock(spawn);
+		BlockPos spawn = new BlockPos(world.getSpawnPoint());
+		spawn = world.getTopSolidOrLiquidBlock(spawn);
 		return spawn;
 	}
 }

--- a/src/main/java/com/vashmeed/nvoid/world/WorldProviderVoidNether.java
+++ b/src/main/java/com/vashmeed/nvoid/world/WorldProviderVoidNether.java
@@ -1,10 +1,13 @@
 package com.vashmeed.nvoid.world;
 
+import com.vashmeed.nvoid.config.Config;
 import com.vashmeed.nvoid.world.biome.VoidBiomeProvider;
 import com.vashmeed.nvoid.world.gen.ChunkGeneratorVoidNether;
 
+import net.minecraft.init.Biomes;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.WorldProviderHell;
+import net.minecraft.world.biome.BiomeProviderSingle;
 import net.minecraft.world.gen.IChunkGenerator;
 
 
@@ -22,9 +25,11 @@ public class WorldProviderVoidNether extends WorldProviderHell {
 
 	@Override
 	public void init() {
-		this.biomeProvider = new VoidBiomeProvider(world);
-		this.doesWaterVaporize = true;
-		this.nether = true;
+		// Always call superclass init and then replace only the biome provider as necessary
+		super.init();
+		if (Config.voidBiomeNether) {
+			this.biomeProvider = new VoidBiomeProvider(world);
+		}
 	}
 
 	@Override

--- a/src/main/java/com/vashmeed/nvoid/world/WorldProviderVoidOverworld.java
+++ b/src/main/java/com/vashmeed/nvoid/world/WorldProviderVoidOverworld.java
@@ -5,11 +5,8 @@ import com.vashmeed.nvoid.world.gen.ChunkGeneratorVoidOverworld;
 
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.WorldProviderSurface;
-import net.minecraft.world.chunk.IChunkGenerator;
+import net.minecraft.world.gen.IChunkGenerator;
 
-/**
- * Created by Vaheed on 11/1/2016.
- */
 public class WorldProviderVoidOverworld extends WorldProviderSurface {
 
 	@Override
@@ -19,18 +16,18 @@ public class WorldProviderVoidOverworld extends WorldProviderSurface {
 
 	@Override
 	public IChunkGenerator createChunkGenerator() {
-		return new ChunkGeneratorVoidOverworld(worldObj);
+		return new ChunkGeneratorVoidOverworld(world);
 	}
 
 	@Override
-	protected void createBiomeProvider() {
-		this.biomeProvider = new VoidBiomeProvider(worldObj);
+	protected void init() {
+		this.biomeProvider = new VoidBiomeProvider(world);
 	}
 
 	@Override
 	public BlockPos getRandomizedSpawnPoint() {
-		BlockPos spawn = new BlockPos(worldObj.getSpawnPoint());
-		spawn = worldObj.getTopSolidOrLiquidBlock(spawn);
+		BlockPos spawn = new BlockPos(world.getSpawnPoint());
+		spawn = world.getTopSolidOrLiquidBlock(spawn);
 		return spawn;
 	}
 

--- a/src/main/java/com/vashmeed/nvoid/world/WorldProviderVoidOverworld.java
+++ b/src/main/java/com/vashmeed/nvoid/world/WorldProviderVoidOverworld.java
@@ -1,5 +1,6 @@
 package com.vashmeed.nvoid.world;
 
+import com.vashmeed.nvoid.config.Config;
 import com.vashmeed.nvoid.world.biome.VoidBiomeProvider;
 import com.vashmeed.nvoid.world.gen.ChunkGeneratorVoidOverworld;
 
@@ -21,7 +22,11 @@ public class WorldProviderVoidOverworld extends WorldProviderSurface {
 
 	@Override
 	protected void init() {
-		this.biomeProvider = new VoidBiomeProvider(world);
+		// Always call superclass init and then replace only the biome provider as necessary
+		super.init();
+		if (Config.voidBiomeOverworld) {
+			this.biomeProvider = new VoidBiomeProvider(world);
+		}
 	}
 
 	@Override

--- a/src/main/java/com/vashmeed/nvoid/world/WorldTypeVoidEnd.java
+++ b/src/main/java/com/vashmeed/nvoid/world/WorldTypeVoidEnd.java
@@ -1,13 +1,12 @@
 package com.vashmeed.nvoid.world;
 
 import com.vashmeed.nvoid.world.gen.ChunkGeneratorVoidEnd;
-import com.vashmeed.nvoid.world.gen.ChunkGeneratorVoidNether;
 
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.WorldType;
-import net.minecraft.world.chunk.IChunkGenerator;
+import net.minecraft.world.gen.IChunkGenerator;
 
 public class WorldTypeVoidEnd extends WorldType {
 

--- a/src/main/java/com/vashmeed/nvoid/world/WorldTypeVoidNether.java
+++ b/src/main/java/com/vashmeed/nvoid/world/WorldTypeVoidNether.java
@@ -6,7 +6,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.WorldType;
-import net.minecraft.world.chunk.IChunkGenerator;
+import net.minecraft.world.gen.IChunkGenerator;
 
 public class WorldTypeVoidNether extends WorldType {
 

--- a/src/main/java/com/vashmeed/nvoid/world/WorldTypeVoidOverworld.java
+++ b/src/main/java/com/vashmeed/nvoid/world/WorldTypeVoidOverworld.java
@@ -6,7 +6,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.WorldType;
-import net.minecraft.world.chunk.IChunkGenerator;
+import net.minecraft.world.gen.IChunkGenerator;
 
 public class WorldTypeVoidOverworld extends WorldType {
 

--- a/src/main/java/com/vashmeed/nvoid/world/gen/ChunkGeneratorVoidEnd.java
+++ b/src/main/java/com/vashmeed/nvoid/world/gen/ChunkGeneratorVoidEnd.java
@@ -7,9 +7,9 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkPrimer;
-import net.minecraft.world.gen.ChunkProviderFlat;
+import net.minecraft.world.gen.ChunkGeneratorFlat;
 
-public class ChunkGeneratorVoidEnd extends ChunkProviderFlat {
+public class ChunkGeneratorVoidEnd extends ChunkGeneratorFlat {
 
 	private World w;
 
@@ -24,9 +24,9 @@ public class ChunkGeneratorVoidEnd extends ChunkProviderFlat {
 	}
 
 	@Override
-	public Chunk provideChunk(int x, int z) {
+	public Chunk generateChunk(int x, int z) {
 		Chunk c = new Chunk(w, new ChunkPrimer(), x, z);
-		Biome[] abiome = this.w.getBiomeProvider().loadBlockGeneratorData((Biome[]) null, x * 16, z * 16, 16, 16);
+		Biome[] abiome = this.w.getBiomeProvider().getBiomesForGeneration((Biome[]) null, x * 16, z * 16, 16, 16);
 		byte[] ids = c.getBiomeArray();
 
 		for (int i = 0; i < ids.length; ++i) {

--- a/src/main/java/com/vashmeed/nvoid/world/gen/ChunkGeneratorVoidIsland.java
+++ b/src/main/java/com/vashmeed/nvoid/world/gen/ChunkGeneratorVoidIsland.java
@@ -8,12 +8,10 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkPrimer;
-import net.minecraft.world.gen.ChunkProviderEnd;
-import net.minecraft.world.gen.NoiseGeneratorSimplex;
+import net.minecraft.world.gen.ChunkGeneratorEnd;
 import net.minecraft.world.gen.feature.WorldGenEndIsland;
-import net.minecraft.world.gen.structure.MapGenEndCity;
 
-public class ChunkGeneratorVoidIsland extends ChunkProviderEnd {
+public class ChunkGeneratorVoidIsland extends ChunkGeneratorEnd {
 
 	private final Random rand;
     private final World worldObj;
@@ -26,20 +24,20 @@ public class ChunkGeneratorVoidIsland extends ChunkProviderEnd {
     private int chunkX = 0;
     private int chunkZ = 0;
 	
-	public ChunkGeneratorVoidIsland(World worldObjIn, boolean mapFeaturesEnabledIn, long seed) {
-		super(worldObjIn, mapFeaturesEnabledIn, seed);
+	public ChunkGeneratorVoidIsland(World worldObjIn, boolean mapFeaturesEnabledIn, long seed, BlockPos pos) {
+		super(worldObjIn, mapFeaturesEnabledIn, seed, pos);
         this.worldObj = worldObjIn;
         this.mapFeaturesEnabled = mapFeaturesEnabledIn;
         this.rand = new Random(seed);     
 	}
 	
 	@Override
-    public Chunk provideChunk(int x, int z)
+    public Chunk generateChunk(int x, int z)
     {
         this.chunkX = x; this.chunkZ = z;
         this.rand.setSeed((long)x * 341873128712L + (long)z * 132897987541L);
         ChunkPrimer chunkprimer = new ChunkPrimer();
-        this.biomesForGeneration = this.worldObj.getBiomeProvider().loadBlockGeneratorData(this.biomesForGeneration, x * 16, z * 16, 16, 16);
+        this.biomesForGeneration = this.worldObj.getBiomeProvider().getBiomesForGeneration(this.biomesForGeneration, x * 16, z * 16, 16, 16);
         this.setBlocksInChunk(x, z, chunkprimer);
         this.buildSurfaces(chunkprimer);
 
@@ -61,7 +59,7 @@ public class ChunkGeneratorVoidIsland extends ChunkProviderEnd {
         net.minecraftforge.event.ForgeEventFactory.onChunkPopulate(true, this, this.worldObj, this.rand, x, z, false);
         BlockPos blockpos = new BlockPos(x * 16, 0, z * 16);
         
-        this.worldObj.getBiomeGenForCoords(blockpos.add(16, 0, 16)).decorate(this.worldObj, this.worldObj.rand, blockpos);
+        this.worldObj.getBiomeForCoordsBody(blockpos.add(16, 0, 16)).decorate(this.worldObj, this.worldObj.rand, blockpos);
         long i = (long)x * (long)x + (long)z * (long)z;
         
         if (i > 4096L)

--- a/src/main/java/com/vashmeed/nvoid/world/gen/ChunkGeneratorVoidNether.java
+++ b/src/main/java/com/vashmeed/nvoid/world/gen/ChunkGeneratorVoidNether.java
@@ -7,12 +7,9 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkPrimer;
-import net.minecraft.world.gen.ChunkProviderFlat;
+import net.minecraft.world.gen.ChunkGeneratorFlat;
 
-/**
- * Created by Vaheed on 10/31/2016.
- */
-public class ChunkGeneratorVoidNether extends ChunkProviderFlat {
+public class ChunkGeneratorVoidNether extends ChunkGeneratorFlat {
 
 	private World w;
 
@@ -27,9 +24,9 @@ public class ChunkGeneratorVoidNether extends ChunkProviderFlat {
 	}
 
 	@Override
-	public Chunk provideChunk(int x, int z) {
+	public Chunk generateChunk(int x, int z) {
 		Chunk c = new Chunk(w, new ChunkPrimer(), x, z);
-		Biome[] abiome = this.w.getBiomeProvider().loadBlockGeneratorData((Biome[]) null, x * 16, z * 16, 16, 16);
+		Biome[] abiome = this.w.getBiomeProvider().getBiomesForGeneration((Biome[]) null, x * 16, z * 16, 16, 16);
 		byte[] ids = c.getBiomeArray();
 
 		for (int i = 0; i < ids.length; ++i) {

--- a/src/main/java/com/vashmeed/nvoid/world/gen/ChunkGeneratorVoidOverworld.java
+++ b/src/main/java/com/vashmeed/nvoid/world/gen/ChunkGeneratorVoidOverworld.java
@@ -9,9 +9,9 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkPrimer;
-import net.minecraft.world.gen.ChunkProviderFlat;
+import net.minecraft.world.gen.ChunkGeneratorFlat;
 
-public class ChunkGeneratorVoidOverworld extends ChunkProviderFlat {
+public class ChunkGeneratorVoidOverworld extends ChunkGeneratorFlat {
 
 	private World w;
 
@@ -30,9 +30,9 @@ public class ChunkGeneratorVoidOverworld extends ChunkProviderFlat {
 	}
 
 	@Override
-	public Chunk provideChunk(int x, int z) {
+	public Chunk generateChunk(int x, int z) {
 		Chunk c = new Chunk(w, new ChunkPrimer(), x, z);
-		Biome[] abiome = this.w.getBiomeProvider().loadBlockGeneratorData((Biome[]) null, x * 16, z * 16, 16, 16);
+		Biome[] abiome = this.w.getBiomeProvider().getBiomesForGeneration((Biome[]) null, x * 16, z * 16, 16, 16);
 		byte[] ids = c.getBiomeArray();
 
 		for (int i = 0; i < ids.length; ++i) {


### PR DESCRIPTION
This patchset ports nVoid forward to 1.12. In addition, it hooks up some configs that weren't implemented and remove some dead code.